### PR TITLE
Phase 3.2: Docs Reorganization and Integration Prep

### DIFF
--- a/PHASE_3_2_STATUS.md
+++ b/PHASE_3_2_STATUS.md
@@ -1,0 +1,22 @@
+# Phase 3.2: Core File Operations and End-to-End Integration
+
+This branch implements Phase 3.2 of the io-uring-sync project, focusing on:
+
+## Goals
+- End-to-end integration of compio-fs-extended
+- Core file operation refactoring with io_uring
+- Drop-in rsync replacement functionality
+- Performance optimization
+
+## Implementation Plan
+Per docs/IMPLEMENTATION_PLAN.md, this phase will:
+1. Refactor src/copy.rs to use io_uring operations
+2. Improve src/directory.rs with compio-fs-extended
+3. Integrate compio-fs-extended operations throughout
+4. Achieve basic drop-in rsync functionality
+5. Comprehensive testing and validation
+
+## Status
+- Branch created: Mon Oct  6 09:35:25 PDT 2025
+- Ready for development work
+


### PR DESCRIPTION
This PR focuses on Phase 3.2 documentation reorganization and prep work for integration.

- Rename working branch to phase-3-2-docs-reorg
- Add PHASE_3_2_STATUS.md documenting goals and phase plan
- Set stage for upcoming core file operations and end-to-end integration work per docs/IMPLEMENTATION_PLAN.md

Next steps:
- Begin refactoring core file operations (src/copy.rs, src/directory.rs)
- Integrate compio-fs-extended and ensure io_uring-first operations
- Expand end-to-end tests and docs