### PR TITLE
feat(sync): add waiter_count() to Condvar for observability

### DIFF
--- a/crates/compio-sync/src/condvar.rs
+++ b/crates/compio-sync/src/condvar.rs
@@ -222,6 +222,15 @@ impl Condvar {
         // Relaxed ordering is fine - this is just a reset, no synchronization needed
         self.inner.notified.store(false, Ordering::Relaxed);
     }
+
+    /// Get the number of tasks waiting on this condvar
+    ///
+    /// This is useful for tests, debugging, and observability.
+    /// **Note**: The count may be stale by the time you read it due to concurrent notify operations.
+    #[must_use]
+    pub fn waiter_count(&self) -> usize {
+        self.inner.waiters.waiter_count()
+    }
 }
 
 impl Default for Condvar {


### PR DESCRIPTION
## Summary

Add `waiter_count()` method to `Condvar` for testing and observability.

## Changes

- Add public `waiter_count()` method to `compio_sync::Condvar`
- Returns the number of tasks currently waiting on the condition variable
- Useful for testing synchronization behavior and runtime diagnostics

## Why This Change

This method enables:
1. **Testing**: Verify that tasks are actually waiting in the queue (not just scheduled)
2. **Observability**: Monitor condition variable usage in production
3. **Debugging**: Diagnose deadlocks or starvation issues

The count may be stale due to concurrent operations, but it's still valuable for diagnostics.

## Testing

- All 19 compio-sync tests passing
- Method will be used in hardlink synchronization tests (upcoming PR)

## Dependencies

None - standalone enhancement to existing Condvar primitive.

## Related

- Built on top of PR #55 (Condvar implementation)
- Enables testing in upcoming module extraction PR