### PR TITLE
feat(filesystem): add read_file_content helper with DirectoryFd

### DIFF
--- a/docs/projects/trait-filesystem-abstraction/plan.md
+++ b/docs/projects/trait-filesystem-abstraction/plan.md
@@ -319,18 +319,20 @@ Wraps std::fs::DirEntry and implements AsyncDirectoryEntry trait.
 **Requirements**: [implementation-requirements.md](./implementation-requirements.md)
 
 **Tasks**:
-- [ ] Create `src/filesystem/read.rs`
-- [ ] Implement `read_file_content()` using openat
-- [ ] Add tests
+- [x] Create `src/filesystem/read.rs`
+- [x] Implement `read_file_content()` using openat
+- [x] Add tests (5 tests: small, empty, binary, large, error)
 
 **Files**: `src/filesystem/mod.rs`, `src/filesystem/read.rs` (new)
 
 **Time**: 2-3 hours
 
 **Success**:
-- [ ] Uses DirectoryFd::open_file_at()
-- [ ] Uses compio, not std::fs
-- [ ] Tests pass
+- [x] Uses DirectoryFd::open_file_at()
+- [x] Uses compio (not std::fs) for I/O
+- [x] All 5 tests pass
+
+**PR**: https://github.com/jmalicki/arsync/pull/114 ✅
 
 ---
 

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -4,7 +4,9 @@
 //! by both local and remote backends. All operations use DirectoryFd and
 //! *at syscalls for TOCTOU safety.
 
+pub mod read;
 pub mod walker;
 
 #[allow(unused_imports)] // Will be used in PR #12 and later
+pub use read::read_file_content;
 pub use walker::SecureTreeWalker;

--- a/src/filesystem/read.rs
+++ b/src/filesystem/read.rs
@@ -47,6 +47,7 @@ use std::ffi::OsStr;
 ///     Ok(())
 /// }
 /// ```
+#[allow(dead_code)] // Will be used in PR #12 and later
 pub async fn read_file_content(dir_fd: &DirectoryFd, filename: &OsStr) -> Result<Vec<u8>> {
     // Open file using DirectoryFd (TOCTOU-safe openat)
     let file = dir_fd

--- a/src/filesystem/read.rs
+++ b/src/filesystem/read.rs
@@ -61,9 +61,6 @@ pub async fn read_file_content(dir_fd: &DirectoryFd, filename: &OsStr) -> Result
         })?;
 
     // Get file size for allocation
-    use std::os::unix::fs::MetadataExt;
-    use std::time::SystemTime;
-
     let m = file
         .metadata()
         .await

--- a/src/filesystem/read.rs
+++ b/src/filesystem/read.rs
@@ -1,0 +1,181 @@
+//! Secure file reading using DirectoryFd
+//!
+//! Provides TOCTOU-safe file reading operations using DirectoryFd and openat.
+
+use crate::error::{Result, SyncError};
+use compio::io::AsyncReadAt;
+use compio_fs_extended::DirectoryFd;
+use std::ffi::OsStr;
+
+/// Read entire file content using DirectoryFd (TOCTOU-safe)
+///
+/// Reads a file using `openat` relative to a directory file descriptor,
+/// ensuring TOCTOU safety and avoiding symlink attacks.
+///
+/// # Parameters
+///
+/// * `dir_fd` - Parent directory file descriptor
+/// * `filename` - File name relative to directory (basename only, no path separators)
+///
+/// # Returns
+///
+/// Returns `Ok(Vec<u8>)` containing the entire file content
+///
+/// # Errors
+///
+/// Returns `Err(SyncError)` if:
+/// - File cannot be opened
+/// - File cannot be read
+/// - I/O error occurs
+///
+/// # Security
+///
+/// Uses `openat(dirfd, filename, ...)` which is TOCTOU-safe.
+/// Does not use path-based operations.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use arsync::filesystem::read_file_content;
+/// use compio_fs_extended::DirectoryFd;
+///
+/// #[compio::main]
+/// async fn main() -> arsync::Result<()> {
+///     let dir_fd = DirectoryFd::open("/some/directory").await?;
+///     let content = read_file_content(&dir_fd, "file.txt").await?;
+///     println!("Read {} bytes", content.len());
+///     Ok(())
+/// }
+/// ```
+pub async fn read_file_content(dir_fd: &DirectoryFd, filename: &OsStr) -> Result<Vec<u8>> {
+    // Open file using DirectoryFd (TOCTOU-safe openat)
+    let file = dir_fd
+        .open_file_at(filename, true, false, false, false)
+        .await
+        .map_err(|e| {
+            SyncError::FileSystem(format!(
+                "Failed to open file '{}' in {}: {e}",
+                filename.to_string_lossy(),
+                dir_fd.path().display()
+            ))
+        })?;
+
+    // Get file size for allocation
+    use std::os::unix::fs::MetadataExt;
+    use std::time::SystemTime;
+
+    let m = file
+        .metadata()
+        .await
+        .map_err(|e| SyncError::FileSystem(format!("Failed to get file metadata: {e}")))?;
+
+    let file_size = m.len() as usize;
+
+    // Allocate buffer
+    let mut content = vec![0u8; file_size];
+    let mut offset = 0u64;
+
+    // Read entire file
+    while offset < file_size as u64 {
+        let remaining = file_size - offset as usize;
+        let chunk_buffer = vec![0u8; remaining];
+
+        let buf_result = file.read_at(chunk_buffer, offset).await;
+        let bytes_read = buf_result.0.map_err(|e| {
+            SyncError::FileSystem(format!("Failed to read from file at offset {offset}: {e}"))
+        })?;
+
+        if bytes_read == 0 {
+            break; // EOF
+        }
+
+        // Copy into result buffer
+        content[offset as usize..offset as usize + bytes_read]
+            .copy_from_slice(&buf_result.1[..bytes_read]);
+
+        offset += bytes_read as u64;
+    }
+
+    // Truncate if we read less than expected
+    content.truncate(offset as usize);
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[compio::test]
+    async fn test_read_small_file() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, b"Hello, World!")?;
+
+        let dir_fd = DirectoryFd::open(temp_dir.path()).await?;
+        let content = read_file_content(&dir_fd, OsStr::new("test.txt")).await?;
+
+        assert_eq!(content, b"Hello, World!");
+
+        Ok(())
+    }
+
+    #[compio::test]
+    async fn test_read_empty_file() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_path = temp_dir.path().join("empty.txt");
+        fs::File::create(&file_path)?;
+
+        let dir_fd = DirectoryFd::open(temp_dir.path()).await?;
+        let content = read_file_content(&dir_fd, OsStr::new("empty.txt")).await?;
+
+        assert_eq!(content.len(), 0);
+
+        Ok(())
+    }
+
+    #[compio::test]
+    async fn test_read_binary_file() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_path = temp_dir.path().join("data.bin");
+        let data: Vec<u8> = (0..=255).collect();
+        fs::write(&file_path, &data)?;
+
+        let dir_fd = DirectoryFd::open(temp_dir.path()).await?;
+        let content = read_file_content(&dir_fd, OsStr::new("data.bin")).await?;
+
+        assert_eq!(content, data);
+
+        Ok(())
+    }
+
+    #[compio::test]
+    async fn test_read_large_file() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_path = temp_dir.path().join("large.dat");
+        let data = vec![0x42u8; 1024 * 1024]; // 1MB
+        fs::write(&file_path, &data)?;
+
+        let dir_fd = DirectoryFd::open(temp_dir.path()).await?;
+        let content = read_file_content(&dir_fd, OsStr::new("large.dat")).await?;
+
+        assert_eq!(content.len(), 1024 * 1024);
+        assert!(content.iter().all(|&b| b == 0x42));
+
+        Ok(())
+    }
+
+    #[compio::test]
+    async fn test_read_nonexistent_file() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+
+        let dir_fd = DirectoryFd::open(temp_dir.path()).await?;
+        let result = read_file_content(&dir_fd, OsStr::new("nonexistent.txt")).await;
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Adds read_file_content() for secure file reading
- Uses DirectoryFd + openat (TOCTOU-safe)
- Shared helper for both local and protocol backends
- All 5 integration tests passing

## Motivation
- Part of trait-based filesystem abstraction (PR #9 in sequence)
- Provides secure file reading using DirectoryFd
- Eliminates duplicate file reading logic across backends
- Foundation for unified I/O operations

## Changes
- **New file**: `src/filesystem/read.rs`
- **Function**: `read_file_content(dir_fd, filename)`
- **Security**: Uses `openat` via `DirectoryFd::open_file_at()`
- **Tests**: 5 comprehensive tests

## Implementation Details
Uses DirectoryFd for secure operations:
1. `dir_fd.open_file_at(filename, ...)` - TOCTOU-safe open
2. `file.metadata()` - Get size for allocation
3. `file.read_at()` - Read file content using compio
4. Returns complete file content as `Vec<u8>`

**Security Properties**:
- ✅ No TOCTOU vulnerabilities
- ✅ No symlink race conditions
- ✅ Uses openat, not open
- ✅ All ops relative to directory fd

## Test Plan
- ✅ Unit tests: `cargo test --lib filesystem::read` (5/5 passing)
  - test_read_small_file - 13 bytes
  - test_read_empty_file - 0 bytes
  - test_read_binary_file - full byte range
  - test_read_large_file - 1MB file
  - test_read_nonexistent_file - error handling
- ✅ Formatted

## Risks & Rollback
- **Risks**: None - additive change, no existing code affected
- **Rollback**: Remove src/filesystem/read.rs, revert mod.rs export

## Performance Impact
- Uses compio async I/O
- Single metadata syscall for file size
- Efficient chunked reading
- Same performance as existing code

## Links
- Part of: trait-based filesystem abstraction design
- Stacks on: PR #8 (SecureTreeWalker)
- Next: PR #10 (write_file_content helper)